### PR TITLE
Deserialize `BitSet`

### DIFF
--- a/src/fastfield/alive_bitset.rs
+++ b/src/fastfield/alive_bitset.rs
@@ -1,7 +1,7 @@
 use std::io;
 use std::io::Write;
 
-use common::{intersect_bitsets, BitSet, OwnedBytes, ReadOnlyBitSet, GenericBitSet};
+use common::{intersect_bitsets, BitSet, OwnedBytes, ReadOnlyBitSet};
 
 use crate::space_usage::ByteCount;
 use crate::DocId;

--- a/src/indexer/index_writer.rs
+++ b/src/indexer/index_writer.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::thread;
 use std::thread::JoinHandle;
 
-use common::{BitSet, GenericBitSet};
+use common::BitSet;
 use smallvec::smallvec;
 
 use super::operation::{AddOperation, UserOperation};


### PR DESCRIPTION
We need the ability to read a mutable `BitSet` from disk so we can update when documents in previous segments are deleted. 