### PR TITLE
Revert "into_term_dictionary method to get TermDictionary"

### DIFF
--- a/src/core/inverted_index_reader.rs
+++ b/src/core/inverted_index_reader.rs
@@ -69,11 +69,6 @@ impl InvertedIndexReader {
         &self.termdict
     }
 
-    /// Turn into a term dictionary
-    pub fn into_term_dictionary(self) -> TermDictionary {
-        self.termdict
-    }
-
     /// Resets the block segment to another position of the postings
     /// file.
     ///


### PR DESCRIPTION
Reverts get-convex/tantivy#6

I actually don't need this because I can just take an `Arc<InvertedIndex>`